### PR TITLE
Improvements to schema and enum naming

### DIFF
--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -150,7 +150,7 @@ class _Project:
         # Generate enums
         enum_template = self.env.get_template("enum.pyi")
         for enum in self.openapi.enums.values():
-            module_path = models_dir / f"{enum.name}.py"
+            module_path = models_dir / f"{enum.reference.module_name}.py"
             module_path.write_text(enum_template.render(enum=enum))
             imports.append(import_string_from_reference(enum.reference))
 

--- a/openapi_python_client/openapi_parser/openapi.py
+++ b/openapi_python_client/openapi_parser/openapi.py
@@ -154,7 +154,7 @@ class Schema:
     relative_imports: Set[str]
 
     @staticmethod
-    def from_dict(d: Dict[str, Any], /, name: str = None) -> Schema:
+    def from_dict(d: Dict[str, Any], /, name: str) -> Schema:
         """ A single Schema from its dict representation
         :param d:    Dict representation of the schema
         :param name: Name by which the schema is referenced, such as a model name.  Used to infer the type name if a `title` property is not available.

--- a/openapi_python_client/openapi_parser/properties.py
+++ b/openapi_python_client/openapi_parser/properties.py
@@ -146,10 +146,9 @@ class EnumProperty(Property):
     """ A property that should use an enum """
 
     values: Dict[str, str]
-    reference: Reference = field(init=False)
+    reference: Reference = field(init=True)
 
     def __post_init__(self) -> None:
-        self.reference = Reference.from_ref(self.name)
         inverse_values = {v: k for k, v in self.values.items()}
         if self.default is not None:
             self.default = f"{self.reference.class_name}.{inverse_values[self.default]}"
@@ -227,6 +226,7 @@ def property_from_dict(name: str, required: bool, data: Dict[str, Any]) -> Prope
             name=name,
             required=required,
             values=EnumProperty.values_from_list(data["enum"]),
+            reference=Reference.from_ref(data.get("title", name)),
             default=data.get("default"),
         )
     if "$ref" in data:

--- a/openapi_python_client/openapi_parser/properties.py
+++ b/openapi_python_client/openapi_parser/properties.py
@@ -146,7 +146,7 @@ class EnumProperty(Property):
     """ A property that should use an enum """
 
     values: Dict[str, str]
-    reference: Reference = field(init=True)
+    reference: Reference
 
     def __post_init__(self) -> None:
         inverse_values = {v: k for k, v in self.values.items()}

--- a/openapi_python_client/openapi_parser/reference.py
+++ b/openapi_python_client/openapi_parser/reference.py
@@ -21,9 +21,10 @@ class Reference:
     def from_ref(ref: str) -> Reference:
         """ Get a Reference from the openapi #/schemas/blahblah string """
         ref_value = ref.split("/")[-1]
-        class_name = stringcase.pascalcase(ref_value)
+        # ugly hack to avoid stringcase ugly pascalcase output when ref_value isn't snake case
+        class_name = stringcase.pascalcase(ref_value.replace(" ", ""))
 
         if class_name in class_overrides:
             return class_overrides[class_name]
 
-        return Reference(class_name=class_name, module_name=stringcase.snakecase(ref_value),)
+        return Reference(class_name=class_name, module_name=stringcase.snakecase(class_name),)

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -274,10 +274,14 @@ class TestProject:
             "__init__.py": models_init,
             f"{schema_1.reference.module_name}.py": schema_1_module_path,
             f"{schema_2.reference.module_name}.py": schema_2_module_path,
-            f"{enum_1.name}.py": enum_1_module_path,
-            f"{enum_2.name}.py": enum_2_module_path,
+            f"{enum_1.reference.module_name}.py": enum_1_module_path,
+            f"{enum_2.reference.module_name}.py": enum_2_module_path,
         }
-        models_dir.__truediv__.side_effect = lambda x: module_paths[x]
+
+        def models_dir_get(x):
+            return module_paths[x]
+
+        models_dir.__truediv__.side_effect = models_dir_get
         project.package_dir.__truediv__.return_value = models_dir
         model_render_1 = mocker.MagicMock()
         model_render_2 = mocker.MagicMock()

--- a/tests/test_openapi_parser/test_openapi.py
+++ b/tests/test_openapi_parser/test_openapi.py
@@ -1,5 +1,7 @@
 import pytest
 
+from openapi_python_client.openapi_parser.reference import Reference
+
 MODULE_NAME = "openapi_python_client.openapi_parser.openapi"
 
 
@@ -43,7 +45,7 @@ class TestOpenAPI:
         from openapi_python_client.openapi_parser.properties import EnumProperty, StringProperty
 
         def _make_enum():
-            return EnumProperty(name=mocker.MagicMock(), required=True, default=None, values=mocker.MagicMock(),)
+            return EnumProperty(name=mocker.MagicMock(), required=True, default=None, values=mocker.MagicMock(), reference=mocker.MagicMock())
 
         # Multiple schemas with both required and optional properties for making sure iteration works correctly
         schema_1 = mocker.MagicMock()
@@ -119,7 +121,7 @@ class TestOpenAPI:
 
         schema = mocker.MagicMock()
 
-        enum_1 = EnumProperty(name=mocker.MagicMock(), required=True, default=None, values=mocker.MagicMock(),)
+        enum_1 = EnumProperty(name=mocker.MagicMock(), required=True, default=None, values=mocker.MagicMock(), reference=mocker.MagicMock())
         enum_2 = replace(enum_1, values=mocker.MagicMock())
         schema.required_properties = [enum_1, enum_2]
 
@@ -139,7 +141,7 @@ class TestSchema:
 
         result = Schema.dict(in_data)
 
-        from_dict.assert_has_calls([mocker.call(value) for value in in_data.values()])
+        from_dict.assert_has_calls([mocker.call(value, name=name) for (name, value) in in_data.items()])
         assert result == {
             schema_1.reference.class_name: schema_1,
             schema_2.reference.class_name: schema_2,
@@ -154,7 +156,7 @@ class TestSchema:
             "required": ["RequiredEnum"],
             "properties": {"RequiredEnum": mocker.MagicMock(), "OptionalString": mocker.MagicMock(),},
         }
-        required_property = EnumProperty(name="RequiredEnum", required=True, default=None, values={},)
+        required_property = EnumProperty(name="RequiredEnum", required=True, default=None, values={}, reference=Reference.from_ref("RequiredEnum"))
         optional_property = StringProperty(name="OptionalString", required=False, default=None)
         property_from_dict = mocker.patch(
             f"{MODULE_NAME}.property_from_dict", side_effect=[required_property, optional_property]
@@ -347,8 +349,8 @@ class TestEndpoint:
             tag="tag",
             relative_imports={"import_3"},
         )
-        path_prop = EnumProperty(name="path_enum", required=True, default=None, values={})
-        query_prop = EnumProperty(name="query_enum", required=False, default=None, values={})
+        path_prop = EnumProperty(name="path_enum", required=True, default=None, values={}, reference=mocker.MagicMock())
+        query_prop = EnumProperty(name="query_enum", required=False, default=None, values={}, reference=mocker.MagicMock())
         propety_from_dict = mocker.patch(f"{MODULE_NAME}.property_from_dict", side_effect=[path_prop, query_prop])
         path_schema = mocker.MagicMock()
         query_schema = mocker.MagicMock()


### PR DESCRIPTION
* name schemas using the declaring property name if no `"title"` property is available. Currently the generator breaks when processing cases such as :

  ```
  CoolFunModel:
      type: object
      properties: {...}
  ```

  This will use `CoolFunModel` as the schema name in these cases.

* Conversely, for enum properties, if a `title` property is available in the property schema then ths this is used to name the enum.  This also addresses #21 - in the case where repeated property enums are derived from a single enum in a typed language (e.g. Java), if they have the same `title` they will be merged back into a single Python enum in the client.