### PR TITLE
Sanitize enum identifiers

### DIFF
--- a/end_to_end_tests/fastapi_app/openapi.json
+++ b/end_to_end_tests/fastapi_app/openapi.json
@@ -244,7 +244,9 @@
                 "title": "AnEnum",
                 "enum": [
                     "FIRST_VALUE",
-                    "SECOND_VALUE"
+                    "camelCase",
+                    "sort:asc",
+                    "type"
                 ],
                 "description": "For testing Enums in all the ways they can be used "
             },

--- a/end_to_end_tests/golden-master/my_test_api_client/models/an_enum.py
+++ b/end_to_end_tests/golden-master/my_test_api_client/models/an_enum.py
@@ -3,4 +3,6 @@ from enum import Enum
 
 class AnEnum(str, Enum):
     FIRST_VALUE = "FIRST_VALUE"
-    SECOND_VALUE = "SECOND_VALUE"
+    CAMELCASE = "camelCase"
+    SORTASC = "sort:asc"
+    TYPE = "type"

--- a/openapi_python_client/parser/properties.py
+++ b/openapi_python_client/parser/properties.py
@@ -293,7 +293,7 @@ class EnumProperty(Property):
 
         for i, value in enumerate(values):
             if value[0].isalpha():
-                key = value.upper()
+                key = utils.sanitize(value.upper())
             else:
                 key = f"VALUE_{i}"
             if key in output:

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -1,12 +1,40 @@
+import keyword
 import re
 
 import stringcase
 
 
+def _shadow_keyword(value: str) -> str:
+    """If the value is a keyword, append an underscore
+    """
+    if keyword.iskeyword(value):
+        return f"{value}_"
+    return value
+
+
+def sanitize(value: str) -> str:
+    """Sanitize value to be a valid python identifier
+
+    Uses the following grammar:
+    identifier ::=  (letter|"_") (letter | digit | "_")*
+    letter     ::=  lowercase | uppercase
+    lowercase  ::=  "a"..."z"
+    uppercase  ::=  "A"..."Z"
+    digit      ::=  "0"..."9"
+    """
+    if value.isidentifier():
+        return _shadow_keyword(value)
+    # Drop invalid characters
+    value = re.sub("[^0-9a-zA-Z_]", "", value)
+    # Drop invalid start characters
+    value = re.sub("^[^a-zA-Z_]+", "", value)
+    return _shadow_keyword(value)
+
+
 def snake_case(value: str) -> str:
     value = re.sub(r"([A-Z]{2,})([A-Z][a-z]|[ -_]|$)", lambda m: m.group(1).title() + m.group(2), value.strip())
     value = re.sub(r"(^|[ _-])([A-Z])", lambda m: m.group(1) + m.group(2).lower(), value)
-    return stringcase.snakecase(value)
+    return sanitize(stringcase.snakecase(value))
 
 
 def pascal_case(value: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,5 +20,17 @@ def test_snake_case_from_camel():
     assert utils.snake_case("httpResponseLowerCamel") == "http_response_lower_camel"
 
 
+def test_sanitized_snake_case():
+    assert utils.snake_case("httpResponseLowerCamel:$!*(") == "http_response_lower_camel"
+
+
+def test_sanitized():
+    assert utils.sanitize("1variable_name:$!*(") == "variable_name"
+
+
+def test_sanitized_keyword():
+    assert utils.sanitize("await") == "await_"
+
+
 def test_spinal_case():
     assert utils.spinal_case("keep_alive") == "keep-alive"


### PR DESCRIPTION
Fixes #149 

This PR fixes an issue where variable names (set to .python_name , or used in enums) are not sanitized, so they can include characters that are invalid.