### PR TITLE
Add a setting to override the package version

### DIFF
--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -29,6 +29,7 @@ class Project:
     TEMPLATE_FILTERS = {"snakecase": utils.snake_case, "kebabcase": utils.kebab_case}
     project_name_override: Optional[str] = None
     package_name_override: Optional[str] = None
+    package_version_override: Optional[str] = None
 
     def __init__(self, *, openapi: GeneratorData) -> None:
         self.openapi: GeneratorData = openapi
@@ -42,7 +43,7 @@ class Project:
         self.package_description: str = utils.remove_string_escapes(
             f"A client library for accessing {self.openapi.title}"
         )
-        self.version: str = openapi.version
+        self.version: str = self.package_version_override or openapi.version
 
         self.env.filters.update(self.TEMPLATE_FILTERS)
 

--- a/openapi_python_client/config.py
+++ b/openapi_python_client/config.py
@@ -14,6 +14,7 @@ class Config(BaseModel):
     class_overrides: Optional[Dict[str, ClassOverride]]
     project_name_override: Optional[str]
     package_name_override: Optional[str]
+    package_version_override: Optional[str]
     field_prefix: Optional[str]
 
     def load_config(self) -> None:
@@ -29,6 +30,7 @@ class Config(BaseModel):
 
         Project.project_name_override = self.project_name_override
         Project.package_name_override = self.package_name_override
+        Project.package_version_override = self.package_version_override
 
         if self.field_prefix is not None:
             utils.FIELD_PREFIX = self.field_prefix

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,14 +25,19 @@ class TestLoadConfig:
         assert reference.class_overrides["Class1"] == reference.Reference(**override1)
         assert reference.class_overrides["Class2"] == reference.Reference(**override2)
 
-    def test_project_and_package_name_overrides(self):
-        config = Config(project_name_override="project-name", package_name_override="package_name")
+    def test_project_and_package_name_and_package_version_overrides(self):
+        config = Config(
+            project_name_override="project-name",
+            package_name_override="package_name",
+            package_version_override="package_version",
+        )
         config.load_config()
 
         from openapi_python_client import Project
 
         assert Project.project_name_override == "project-name"
         assert Project.package_name_override == "package_name"
+        assert Project.package_version_override == "package_version"
 
     def test_field_prefix(self):
         Config(field_prefix="blah").load_config()


### PR DESCRIPTION
A generate package version actually depends on the version of the
OpenAPI spec and on the version of the generator. Upgrading the
generator version may break backward compatibility of the client. This
gives the user the possibility to bump its client version to reflect
changes in the generated code even though the spec has not changed.