### PR TITLE
Fix indentation in unions with refs

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/defaults_tests_defaults_post.py
@@ -48,6 +48,7 @@ def httpx_request(
     boolean_prop: Union[Unset, bool] = False,
     list_prop: Union[Unset, List[AnEnum]] = UNSET,
     union_prop: Union[Unset, float, str] = "not a float",
+    union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
 ) -> Response[Union[None, HTTPValidationError]]:
 
@@ -75,6 +76,16 @@ def httpx_request(
     else:
         json_union_prop = union_prop
 
+    json_union_prop_with_ref: Union[Unset, float, AnEnum]
+    if isinstance(union_prop_with_ref, Unset):
+        json_union_prop_with_ref = UNSET
+    elif isinstance(union_prop_with_ref, float):
+        json_union_prop_with_ref = union_prop_with_ref
+    else:
+        json_union_prop_with_ref = UNSET
+        if not isinstance(union_prop_with_ref, Unset):
+            json_union_prop_with_ref = union_prop_with_ref
+
     json_enum_prop: Union[Unset, AnEnum] = UNSET
     if not isinstance(enum_prop, Unset):
         json_enum_prop = enum_prop
@@ -96,6 +107,8 @@ def httpx_request(
         params["list_prop"] = json_list_prop
     if union_prop is not UNSET:
         params["union_prop"] = json_union_prop
+    if union_prop_with_ref is not UNSET:
+        params["union_prop_with_ref"] = json_union_prop_with_ref
     if enum_prop is not UNSET:
         params["enum_prop"] = json_enum_prop
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -21,6 +21,7 @@ def _get_kwargs(
     boolean_prop: Union[Unset, bool] = False,
     list_prop: Union[Unset, List[AnEnum]] = UNSET,
     union_prop: Union[Unset, float, str] = "not a float",
+    union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
 ) -> Dict[str, Any]:
     url = "{}/tests/defaults".format(client.base_url)
@@ -51,6 +52,16 @@ def _get_kwargs(
     else:
         json_union_prop = union_prop
 
+    json_union_prop_with_ref: Union[Unset, float, AnEnum]
+    if isinstance(union_prop_with_ref, Unset):
+        json_union_prop_with_ref = UNSET
+    elif isinstance(union_prop_with_ref, float):
+        json_union_prop_with_ref = union_prop_with_ref
+    else:
+        json_union_prop_with_ref = UNSET
+        if not isinstance(union_prop_with_ref, Unset):
+            json_union_prop_with_ref = union_prop_with_ref
+
     json_enum_prop: Union[Unset, AnEnum] = UNSET
     if not isinstance(enum_prop, Unset):
         json_enum_prop = enum_prop
@@ -72,6 +83,8 @@ def _get_kwargs(
         params["list_prop"] = json_list_prop
     if union_prop is not UNSET:
         params["union_prop"] = json_union_prop
+    if union_prop_with_ref is not UNSET:
+        params["union_prop_with_ref"] = json_union_prop_with_ref
     if enum_prop is not UNSET:
         params["enum_prop"] = json_enum_prop
 
@@ -116,6 +129,7 @@ def sync_detailed(
     boolean_prop: Union[Unset, bool] = False,
     list_prop: Union[Unset, List[AnEnum]] = UNSET,
     union_prop: Union[Unset, float, str] = "not a float",
+    union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
 ) -> Response[Union[None, HTTPValidationError]]:
     kwargs = _get_kwargs(
@@ -128,6 +142,7 @@ def sync_detailed(
         boolean_prop=boolean_prop,
         list_prop=list_prop,
         union_prop=union_prop,
+        union_prop_with_ref=union_prop_with_ref,
         enum_prop=enum_prop,
     )
 
@@ -149,6 +164,7 @@ def sync(
     boolean_prop: Union[Unset, bool] = False,
     list_prop: Union[Unset, List[AnEnum]] = UNSET,
     union_prop: Union[Unset, float, str] = "not a float",
+    union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
 ) -> Optional[Union[None, HTTPValidationError]]:
     """  """
@@ -163,6 +179,7 @@ def sync(
         boolean_prop=boolean_prop,
         list_prop=list_prop,
         union_prop=union_prop,
+        union_prop_with_ref=union_prop_with_ref,
         enum_prop=enum_prop,
     ).parsed
 
@@ -178,6 +195,7 @@ async def asyncio_detailed(
     boolean_prop: Union[Unset, bool] = False,
     list_prop: Union[Unset, List[AnEnum]] = UNSET,
     union_prop: Union[Unset, float, str] = "not a float",
+    union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
 ) -> Response[Union[None, HTTPValidationError]]:
     kwargs = _get_kwargs(
@@ -190,6 +208,7 @@ async def asyncio_detailed(
         boolean_prop=boolean_prop,
         list_prop=list_prop,
         union_prop=union_prop,
+        union_prop_with_ref=union_prop_with_ref,
         enum_prop=enum_prop,
     )
 
@@ -210,6 +229,7 @@ async def asyncio(
     boolean_prop: Union[Unset, bool] = False,
     list_prop: Union[Unset, List[AnEnum]] = UNSET,
     union_prop: Union[Unset, float, str] = "not a float",
+    union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
 ) -> Optional[Union[None, HTTPValidationError]]:
     """  """
@@ -225,6 +245,7 @@ async def asyncio(
             boolean_prop=boolean_prop,
             list_prop=list_prop,
             union_prop=union_prop,
+            union_prop_with_ref=union_prop_with_ref,
             enum_prop=enum_prop,
         )
     ).parsed

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -375,6 +375,23 @@
           {
             "required": false,
             "schema": {
+              "title": "Union Prop With Ref",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/components/schemas/AnEnum"
+                }
+              ],
+              "default": 0.6
+            },
+            "name": "union_prop_with_ref",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
               "$ref": "#/components/schemas/AnEnum"
             },
             "name": "enum_prop",


### PR DESCRIPTION
* Add a query parameter in golden record to test schema with "anyOf": { "$ref": ...}
* Seems to me that there was some over indenting in `union_template.pyi`
* Mypy is unhappy, because in the `union_template.pyi` the `transform` macro from sub templates redefines the property, with a different type. How should I fix this?