### PR TITLE
Better naming of sub-model classes

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/test_inline_objects.py
@@ -6,19 +6,19 @@ from ...types import Response
 
 Client = httpx.Client
 
-from ...models.test_inline_objectsjson_body import TestInlineObjectsjsonBody
-from ...models.test_inline_objectsresponse_200 import TestInlineObjectsresponse_200
+from ...models.test_inline_objects_json_body import TestInlineObjects_JsonBody
+from ...models.test_inline_objects_response_200 import TestInlineObjects_Response_200
 
 
-def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjectsresponse_200]:
+def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjects_Response_200]:
     if response.status_code == 200:
-        response_200 = TestInlineObjectsresponse_200.from_dict(response.json())
+        response_200 = TestInlineObjects_Response_200.from_dict(response.json())
 
         return response_200
     return None
 
 
-def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsresponse_200]:
+def _build_response(*, response: httpx.Response) -> Response[TestInlineObjects_Response_200]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -30,8 +30,8 @@ def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsre
 def httpx_request(
     *,
     client: Client,
-    json_body: TestInlineObjectsjsonBody,
-) -> Response[TestInlineObjectsresponse_200]:
+    json_body: TestInlineObjects_JsonBody,
+) -> Response[TestInlineObjects_Response_200]:
 
     json_json_body = json_body.to_dict()
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/test_inline_objects.py
@@ -6,19 +6,19 @@ from ...types import Response
 
 Client = httpx.Client
 
-from ...models.test_inline_objects_json_body import TestInlineObjects_JsonBody
-from ...models.test_inline_objects_response_200 import TestInlineObjects_Response_200
+from ...models.test_inline_objects_json_body import TestInlineObjectsJsonBody
+from ...models.test_inline_objects_response_200 import TestInlineObjectsResponse_200
 
 
-def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjects_Response_200]:
+def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjectsResponse_200]:
     if response.status_code == 200:
-        response_200 = TestInlineObjects_Response_200.from_dict(response.json())
+        response_200 = TestInlineObjectsResponse_200.from_dict(response.json())
 
         return response_200
     return None
 
 
-def _build_response(*, response: httpx.Response) -> Response[TestInlineObjects_Response_200]:
+def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsResponse_200]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -30,8 +30,8 @@ def _build_response(*, response: httpx.Response) -> Response[TestInlineObjects_R
 def httpx_request(
     *,
     client: Client,
-    json_body: TestInlineObjects_JsonBody,
-) -> Response[TestInlineObjects_Response_200]:
+    json_body: TestInlineObjectsJsonBody,
+) -> Response[TestInlineObjectsResponse_200]:
 
     json_json_body = json_body.to_dict()
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/__init__.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/__init__.py
@@ -7,6 +7,6 @@ from .body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
 from .different_enum import DifferentEnum
 from .http_validation_error import HTTPValidationError
 from .model_with_union_property import ModelWithUnionProperty
-from .test_inline_objectsjson_body import TestInlineObjectsjsonBody
-from .test_inline_objectsresponse_200 import TestInlineObjectsresponse_200
+from .test_inline_objects_json_body import TestInlineObjects_JsonBody
+from .test_inline_objects_response_200 import TestInlineObjects_Response_200
 from .validation_error import ValidationError

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/__init__.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/__init__.py
@@ -7,6 +7,6 @@ from .body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
 from .different_enum import DifferentEnum
 from .http_validation_error import HTTPValidationError
 from .model_with_union_property import ModelWithUnionProperty
-from .test_inline_objects_json_body import TestInlineObjects_JsonBody
-from .test_inline_objects_response_200 import TestInlineObjects_Response_200
+from .test_inline_objects_json_body import TestInlineObjectsJsonBody
+from .test_inline_objects_response_200 import TestInlineObjectsResponse_200
 from .validation_error import ValidationError

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_json_body.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_json_body.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjects_JsonBody:
+class TestInlineObjectsJsonBody:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjects_JsonBody:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_JsonBody":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsJsonBody":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjects_JsonBody(
+        return TestInlineObjectsJsonBody(
             a_property=a_property,
         )

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_json_body.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_json_body.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjectsresponse_200:
+class TestInlineObjects_JsonBody:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjectsresponse_200:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsresponse_200":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_JsonBody":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjectsresponse_200(
+        return TestInlineObjects_JsonBody(
             a_property=a_property,
         )

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_response_200.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_response_200.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjects_Response_200:
+class TestInlineObjectsResponse_200:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjects_Response_200:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_Response_200":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsResponse_200":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjects_Response_200(
+        return TestInlineObjectsResponse_200(
             a_property=a_property,
         )

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_response_200.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_response_200.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjectsjsonBody:
+class TestInlineObjects_Response_200:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjectsjsonBody:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsjsonBody":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_Response_200":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjectsjsonBody(
+        return TestInlineObjects_Response_200(
             a_property=a_property,
         )

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -3,15 +3,15 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
-from ...models.test_inline_objects_json_body import TestInlineObjects_JsonBody
-from ...models.test_inline_objects_response_200 import TestInlineObjects_Response_200
+from ...models.test_inline_objects_json_body import TestInlineObjectsJsonBody
+from ...models.test_inline_objects_response_200 import TestInlineObjectsResponse_200
 from ...types import Response
 
 
 def _get_kwargs(
     *,
     client: Client,
-    json_body: TestInlineObjects_JsonBody,
+    json_body: TestInlineObjectsJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/tests/inline_objects".format(client.base_url)
 
@@ -28,15 +28,15 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjects_Response_200]:
+def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjectsResponse_200]:
     if response.status_code == 200:
-        response_200 = TestInlineObjects_Response_200.from_dict(response.json())
+        response_200 = TestInlineObjectsResponse_200.from_dict(response.json())
 
         return response_200
     return None
 
 
-def _build_response(*, response: httpx.Response) -> Response[TestInlineObjects_Response_200]:
+def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsResponse_200]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -48,8 +48,8 @@ def _build_response(*, response: httpx.Response) -> Response[TestInlineObjects_R
 def sync_detailed(
     *,
     client: Client,
-    json_body: TestInlineObjects_JsonBody,
-) -> Response[TestInlineObjects_Response_200]:
+    json_body: TestInlineObjectsJsonBody,
+) -> Response[TestInlineObjectsResponse_200]:
     kwargs = _get_kwargs(
         client=client,
         json_body=json_body,
@@ -65,8 +65,8 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-    json_body: TestInlineObjects_JsonBody,
-) -> Optional[TestInlineObjects_Response_200]:
+    json_body: TestInlineObjectsJsonBody,
+) -> Optional[TestInlineObjectsResponse_200]:
     """  """
 
     return sync_detailed(
@@ -78,8 +78,8 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-    json_body: TestInlineObjects_JsonBody,
-) -> Response[TestInlineObjects_Response_200]:
+    json_body: TestInlineObjectsJsonBody,
+) -> Response[TestInlineObjectsResponse_200]:
     kwargs = _get_kwargs(
         client=client,
         json_body=json_body,
@@ -94,8 +94,8 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-    json_body: TestInlineObjects_JsonBody,
-) -> Optional[TestInlineObjects_Response_200]:
+    json_body: TestInlineObjectsJsonBody,
+) -> Optional[TestInlineObjectsResponse_200]:
     """  """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -3,15 +3,15 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
-from ...models.test_inline_objectsjson_body import TestInlineObjectsjsonBody
-from ...models.test_inline_objectsresponse_200 import TestInlineObjectsresponse_200
+from ...models.test_inline_objects_json_body import TestInlineObjects_JsonBody
+from ...models.test_inline_objects_response_200 import TestInlineObjects_Response_200
 from ...types import Response
 
 
 def _get_kwargs(
     *,
     client: Client,
-    json_body: TestInlineObjectsjsonBody,
+    json_body: TestInlineObjects_JsonBody,
 ) -> Dict[str, Any]:
     url = "{}/tests/inline_objects".format(client.base_url)
 
@@ -28,15 +28,15 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjectsresponse_200]:
+def _parse_response(*, response: httpx.Response) -> Optional[TestInlineObjects_Response_200]:
     if response.status_code == 200:
-        response_200 = TestInlineObjectsresponse_200.from_dict(response.json())
+        response_200 = TestInlineObjects_Response_200.from_dict(response.json())
 
         return response_200
     return None
 
 
-def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsresponse_200]:
+def _build_response(*, response: httpx.Response) -> Response[TestInlineObjects_Response_200]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -48,8 +48,8 @@ def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsre
 def sync_detailed(
     *,
     client: Client,
-    json_body: TestInlineObjectsjsonBody,
-) -> Response[TestInlineObjectsresponse_200]:
+    json_body: TestInlineObjects_JsonBody,
+) -> Response[TestInlineObjects_Response_200]:
     kwargs = _get_kwargs(
         client=client,
         json_body=json_body,
@@ -65,8 +65,8 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-    json_body: TestInlineObjectsjsonBody,
-) -> Optional[TestInlineObjectsresponse_200]:
+    json_body: TestInlineObjects_JsonBody,
+) -> Optional[TestInlineObjects_Response_200]:
     """  """
 
     return sync_detailed(
@@ -78,8 +78,8 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-    json_body: TestInlineObjectsjsonBody,
-) -> Response[TestInlineObjectsresponse_200]:
+    json_body: TestInlineObjects_JsonBody,
+) -> Response[TestInlineObjects_Response_200]:
     kwargs = _get_kwargs(
         client=client,
         json_body=json_body,
@@ -94,8 +94,8 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-    json_body: TestInlineObjectsjsonBody,
-) -> Optional[TestInlineObjectsresponse_200]:
+    json_body: TestInlineObjects_JsonBody,
+) -> Optional[TestInlineObjects_Response_200]:
     """  """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
@@ -7,6 +7,6 @@ from .body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
 from .different_enum import DifferentEnum
 from .http_validation_error import HTTPValidationError
 from .model_with_union_property import ModelWithUnionProperty
-from .test_inline_objectsjson_body import TestInlineObjectsjsonBody
-from .test_inline_objectsresponse_200 import TestInlineObjectsresponse_200
+from .test_inline_objects_json_body import TestInlineObjects_JsonBody
+from .test_inline_objects_response_200 import TestInlineObjects_Response_200
 from .validation_error import ValidationError

--- a/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
@@ -7,6 +7,6 @@ from .body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
 from .different_enum import DifferentEnum
 from .http_validation_error import HTTPValidationError
 from .model_with_union_property import ModelWithUnionProperty
-from .test_inline_objects_json_body import TestInlineObjects_JsonBody
-from .test_inline_objects_response_200 import TestInlineObjects_Response_200
+from .test_inline_objects_json_body import TestInlineObjectsJsonBody
+from .test_inline_objects_response_200 import TestInlineObjectsResponse_200
 from .validation_error import ValidationError

--- a/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_json_body.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_json_body.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjects_JsonBody:
+class TestInlineObjectsJsonBody:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjects_JsonBody:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_JsonBody":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsJsonBody":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjects_JsonBody(
+        return TestInlineObjectsJsonBody(
             a_property=a_property,
         )

--- a/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_json_body.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_json_body.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjectsresponse_200:
+class TestInlineObjects_JsonBody:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjectsresponse_200:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsresponse_200":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_JsonBody":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjectsresponse_200(
+        return TestInlineObjects_JsonBody(
             a_property=a_property,
         )

--- a/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_response_200.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_response_200.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjects_Response_200:
+class TestInlineObjectsResponse_200:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjects_Response_200:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_Response_200":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsResponse_200":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjects_Response_200(
+        return TestInlineObjectsResponse_200(
             a_property=a_property,
         )

--- a/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_response_200.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_response_200.py
@@ -6,7 +6,7 @@ from ..types import UNSET, Unset
 
 
 @attr.s(auto_attribs=True)
-class TestInlineObjectsjsonBody:
+class TestInlineObjects_Response_200:
     """  """
 
     a_property: Union[Unset, str] = UNSET
@@ -21,9 +21,9 @@ class TestInlineObjectsjsonBody:
         return field_dict
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TestInlineObjectsjsonBody":
+    def from_dict(d: Dict[str, Any]) -> "TestInlineObjects_Response_200":
         a_property = d.get("a_property", UNSET)
 
-        return TestInlineObjectsjsonBody(
+        return TestInlineObjects_Response_200(
             a_property=a_property,
         )

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -373,7 +373,7 @@ def build_list_property(
     if data.items is None:
         return PropertyError(data=data, detail="type array must have items defined"), schemas
     inner_prop, schemas = property_from_data(
-        name=f"{name}_item", required=True, data=data.items, schemas=schemas, parent_name=f"{parent_name}_{name}"
+        name=f"{name}_item", required=True, data=data.items, schemas=schemas, parent_name=parent_name
     )
     if isinstance(inner_prop, PropertyError):
         return PropertyError(data=inner_prop.data, detail=f"invalid data in items of array {name}"), schemas

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -239,7 +239,7 @@ def build_model_property(
 
     class_name = data.title or name
     if parent_name:
-        class_name = f"{utils.pascal_case(parent_name)}_{utils.pascal_case(class_name)}"
+        class_name = f"{utils.pascal_case(parent_name)}{utils.pascal_case(class_name)}"
     ref = Reference.from_ref(class_name)
 
     for key, value in (data.properties or {}).items():
@@ -296,7 +296,7 @@ def build_enum_property(
 
     class_name = data.title or name
     if parent_name:
-        class_name = f"{utils.pascal_case(parent_name)}_{utils.pascal_case(class_name)}"
+        class_name = f"{utils.pascal_case(parent_name)}{utils.pascal_case(class_name)}"
     reference = Reference.from_ref(class_name)
     values = EnumProperty.values_from_list(enum)
 

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -239,7 +239,7 @@ def build_model_property(
 
     class_name = data.title or name
     if parent_name:
-        class_name = f"{utils.pascal_case(parent_name)}{class_name}"
+        class_name = f"{utils.pascal_case(parent_name)}_{utils.pascal_case(class_name)}"
     ref = Reference.from_ref(class_name)
 
     for key, value in (data.properties or {}).items():
@@ -296,7 +296,7 @@ def build_enum_property(
 
     class_name = data.title or name
     if parent_name:
-        class_name = f"{utils.pascal_case(parent_name)}{class_name}"
+        class_name = f"{utils.pascal_case(parent_name)}_{utils.pascal_case(class_name)}"
     reference = Reference.from_ref(class_name)
     values = EnumProperty.values_from_list(enum)
 

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -501,14 +501,14 @@ class TestPropertyFromData:
             required=True,
             nullable=False,
             values={"A": "A", "B": "B", "C": "C"},
-            reference=Reference(class_name="Parent_AnEnum", module_name="parent_an_enum"),
+            reference=Reference(class_name="ParentAnEnum", module_name="parent_an_enum"),
             value_type=str,
-            default="Parent_AnEnum.B",
+            default="ParentAnEnum.B",
         )
         assert schemas != new_schemas, "Provided Schemas was mutated"
         assert new_schemas.enums == {
             "AnEnum": schemas.enums["AnEnum"],
-            "Parent_AnEnum": prop,
+            "ParentAnEnum": prop,
         }
 
     def test_property_from_data_int_enum(self, mocker):
@@ -532,14 +532,14 @@ class TestPropertyFromData:
             required=True,
             nullable=False,
             values={"VALUE_1": 1, "VALUE_2": 2, "VALUE_3": 3},
-            reference=Reference(class_name="Parent_AnEnum", module_name="parent_an_enum"),
+            reference=Reference(class_name="ParentAnEnum", module_name="parent_an_enum"),
             value_type=int,
-            default="Parent_AnEnum.VALUE_3",
+            default="ParentAnEnum.VALUE_3",
         )
         assert schemas != new_schemas, "Provided Schemas was mutated"
         assert new_schemas.enums == {
             "AnEnum": schemas.enums["AnEnum"],
-            "Parent_AnEnum": prop,
+            "ParentAnEnum": prop,
         }
 
     def test_property_from_data_ref_enum(self):
@@ -1065,14 +1065,14 @@ def test_build_model_property():
     assert new_schemas != schemas
     assert new_schemas.models == {
         "OtherModel": None,
-        "Parent_MyModel": model,
+        "ParentMyModel": model,
     }
     assert model == ModelProperty(
         name="prop",
         required=True,
         nullable=False,
         default=None,
-        reference=Reference(class_name="Parent_MyModel", module_name="parent_my_model"),
+        reference=Reference(class_name="ParentMyModel", module_name="parent_my_model"),
         required_properties=[StringProperty(name="req", required=True, nullable=False, default=None)],
         optional_properties=[DateTimeProperty(name="opt", required=False, nullable=False, default=None)],
         description=data.description,

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -501,21 +501,21 @@ class TestPropertyFromData:
             required=True,
             nullable=False,
             values={"A": "A", "B": "B", "C": "C"},
-            reference=Reference(class_name="ParentAnEnum", module_name="parent_an_enum"),
+            reference=Reference(class_name="Parent_AnEnum", module_name="parent_an_enum"),
             value_type=str,
-            default="ParentAnEnum.B",
+            default="Parent_AnEnum.B",
         )
         assert schemas != new_schemas, "Provided Schemas was mutated"
         assert new_schemas.enums == {
             "AnEnum": schemas.enums["AnEnum"],
-            "ParentAnEnum": prop,
+            "Parent_AnEnum": prop,
         }
 
     def test_property_from_data_int_enum(self, mocker):
         from openapi_python_client.parser.properties import EnumProperty, Reference
         from openapi_python_client.schema import Schema
 
-        data = Schema.construct(title="AnEnum", enum=[1, 2, 3], nullable=False, default=3)
+        data = Schema.construct(title="anEnum", enum=[1, 2, 3], nullable=False, default=3)
         name = "my_enum"
         required = True
 
@@ -532,14 +532,14 @@ class TestPropertyFromData:
             required=True,
             nullable=False,
             values={"VALUE_1": 1, "VALUE_2": 2, "VALUE_3": 3},
-            reference=Reference(class_name="ParentAnEnum", module_name="parent_an_enum"),
+            reference=Reference(class_name="Parent_AnEnum", module_name="parent_an_enum"),
             value_type=int,
-            default="ParentAnEnum.VALUE_3",
+            default="Parent_AnEnum.VALUE_3",
         )
         assert schemas != new_schemas, "Provided Schemas was mutated"
         assert new_schemas.enums == {
             "AnEnum": schemas.enums["AnEnum"],
-            "ParentAnEnum": prop,
+            "Parent_AnEnum": prop,
         }
 
     def test_property_from_data_ref_enum(self):
@@ -1065,14 +1065,14 @@ def test_build_model_property():
     assert new_schemas != schemas
     assert new_schemas.models == {
         "OtherModel": None,
-        "ParentMyModel": model,
+        "Parent_MyModel": model,
     }
     assert model == ModelProperty(
         name="prop",
         required=True,
         nullable=False,
         default=None,
-        reference=Reference(class_name="ParentMyModel", module_name="parent_my_model"),
+        reference=Reference(class_name="Parent_MyModel", module_name="parent_my_model"),
         required_properties=[StringProperty(name="req", required=True, nullable=False, default=None)],
         optional_properties=[DateTimeProperty(name="opt", required=False, nullable=False, default=None)],
         description=data.description,

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -820,7 +820,7 @@ class TestBuildListProperty:
         assert new_schemas == second_schemas
         assert schemas != new_schemas, "Schema was mutated"
         property_from_data.assert_called_once_with(
-            name=f"{name}_item", required=True, data=data.items, schemas=schemas, parent_name="parent_name"
+            name=f"{name}_item", required=True, data=data.items, schemas=schemas, parent_name="parent"
         )
 
     def test_build_list_property(self, mocker):
@@ -849,7 +849,7 @@ class TestBuildListProperty:
         assert new_schemas == second_schemas
         assert schemas != new_schemas, "Schema was mutated"
         property_from_data.assert_called_once_with(
-            name=f"{name}_item", required=True, data=data.items, schemas=schemas, parent_name="parent_prop"
+            name=f"{name}_item", required=True, data=data.items, schemas=schemas, parent_name="parent"
         )
 
 


### PR DESCRIPTION
The new naming feature for classes with parent elements in `0.7.0` solves a problem for us, but the capitalization is not ideal.

Currently, if the parent is "`parent`" and the child is "`child`" it will generate classes like:

```python
class Parentchild:
  # ...
```

After this change, it will be
```python
class ParentChild:
  # ...
```

Which has better capitalization. This improves naming consistency when the model/enum is in-lined under a lower-case property and proper caps can't be enforced in the specs.

----

Also updated is list item property naming.

Before, it was doubling the child name when naming the items of a `child` list property of a `parent` class as:

```python
class ParentChildchildItem:
  # ...
```

Now it just does


```python
class ParentChildItem:
  # ...
```