### PR TITLE
Bugfix: Implement __str__ for enum props to fix query string

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/an_enum.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/an_enum.py
@@ -4,3 +4,6 @@ from enum import Enum
 class AnEnum(str, Enum):
     FIRST_VALUE = "FIRST_VALUE"
     SECOND_VALUE = "SECOND_VALUE"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/an_int_enum.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/an_int_enum.py
@@ -5,3 +5,6 @@ class AnIntEnum(IntEnum):
     VALUE_NEGATIVE_1 = -1
     VALUE_1 = 1
     VALUE_2 = 2
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/different_enum.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/different_enum.py
@@ -4,3 +4,6 @@ from enum import Enum
 class DifferentEnum(str, Enum):
     DIFFERENT = "DIFFERENT"
     OTHER = "OTHER"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_enum.py
@@ -4,3 +4,6 @@ from enum import Enum
 class AnEnum(str, Enum):
     FIRST_VALUE = "FIRST_VALUE"
     SECOND_VALUE = "SECOND_VALUE"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_int_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_int_enum.py
@@ -5,3 +5,6 @@ class AnIntEnum(IntEnum):
     VALUE_NEGATIVE_1 = -1
     VALUE_1 = 1
     VALUE_2 = 2
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/different_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/different_enum.py
@@ -4,3 +4,6 @@ from enum import Enum
 class DifferentEnum(str, Enum):
     DIFFERENT = "DIFFERENT"
     OTHER = "OTHER"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/openapi_python_client/templates/int_enum.pyi
+++ b/openapi_python_client/templates/int_enum.pyi
@@ -4,3 +4,6 @@ class {{ enum.reference.class_name }}(IntEnum):
     {% for key, value in enum.values.items() %}
     {{ key }} = {{ value }}
     {% endfor %}
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/openapi_python_client/templates/str_enum.pyi
+++ b/openapi_python_client/templates/str_enum.pyi
@@ -4,3 +4,6 @@ class {{ enum.reference.class_name }}(str, Enum):
     {% for key, value in enum.values.items() %}
     {{ key }} = "{{ value }}"
     {% endfor %}
+
+    def __str__(self) -> str:
+        return str(self.value)


### PR DESCRIPTION
Update both string and int enums to have a `__str__` method that return just the string representation of the value:

```python
    def __str__(self) -> str:
        return str(self.value)
```

----

This fixes a bug introduced in #241 (my bad 😬 ). As I [noted](https://github.com/triaxtec/openapi-python-client/pull/241#discussion_r525654722) on that PR, request bodies will be fine as `json.dumps` will convert the enums correctly. However it does not work for query string params - `urllib.parse.urlencode` (which `httpx` uses here) 
[just does `str(val)`](https://github.com/python/cpython/blob/3.9/Lib/urllib/parse.py#L941), which returns `"EnumClass.key"`.

So
```python
class SomeEnum(str, Enum):
  val = "a_value"

some_endpoint.sync(client=api_client, some_query_string=SomeEnum.val)
```
would result in a query string of `?someQueryString=SomeEnum.val` instead of `?someQueryString=a_value`