### PR TITLE
Fix bug in model property template that was not handling unset properly

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties.py
@@ -31,9 +31,9 @@ class ModelWithPrimitiveAdditionalProperties:
     @staticmethod
     def from_dict(src_dict: Dict[str, Any]) -> "ModelWithPrimitiveAdditionalProperties":
         d = src_dict.copy()
-        a_date_holder = UNSET
+        a_date_holder: Union[ModelWithPrimitiveAdditionalPropertiesADateHolder, Unset] = UNSET
         _a_date_holder = d.pop("a_date_holder", UNSET)
-        if _a_date_holder is not None and not isinstance(a_date_holder, Unset):
+        if _a_date_holder is not None and not isinstance(_a_date_holder, Unset):
             a_date_holder = ModelWithPrimitiveAdditionalPropertiesADateHolder.from_dict(
                 cast(Dict[str, Any], _a_date_holder)
             )

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties.py
@@ -31,9 +31,9 @@ class ModelWithPrimitiveAdditionalProperties:
     @staticmethod
     def from_dict(src_dict: Dict[str, Any]) -> "ModelWithPrimitiveAdditionalProperties":
         d = src_dict.copy()
-        a_date_holder = UNSET
+        a_date_holder: Union[ModelWithPrimitiveAdditionalPropertiesADateHolder, Unset] = UNSET
         _a_date_holder = d.pop("a_date_holder", UNSET)
-        if _a_date_holder is not None and not isinstance(a_date_holder, Unset):
+        if _a_date_holder is not None and not isinstance(_a_date_holder, Unset):
             a_date_holder = ModelWithPrimitiveAdditionalPropertiesADateHolder.from_dict(
                 cast(Dict[str, Any], _a_date_holder)
             )

--- a/openapi_python_client/templates/property_templates/model_property.pyi
+++ b/openapi_python_client/templates/property_templates/model_property.pyi
@@ -7,10 +7,10 @@
 {% elif property.nullable %}
 {{ property.python_name }} = None
 {% else %}
-{{ property.python_name }} = UNSET
+{{ property.python_name }}: {{ property.get_type_string() }} = UNSET
 {% endif %}
 _{{ property.python_name }} = {{source}}
-if _{{ property.python_name }} is not None and not isinstance({{ property.python_name }},  Unset):
+if _{{ property.python_name }} is not None and not isinstance(_{{ property.python_name }},  Unset):
     {{ property.python_name }} = {{ property.reference.class_name }}.from_dict(cast(Dict[str, Any], _{{ property.python_name }}))
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Bugfix for PR #252 

When switching to use `_<property>` as the temp holder for the `pop`ed dict value, I didn't update the `isinstance` check, so it was checking

```python
a_prop = UNSET
_a_prop = d.pop("aProp", UNSET)
if _a_prop is not None and not isinstance(a_prop, Unset):
    a_prop = TheModel.from_dict(cast(Dict[str, Any], _response))
```
and `isinstance(a_prop, Unset)` would always evaluate to True so the value was never parsed.

Required adding type to model variable to please mypy