### PR TITLE
Lower version requirements for python-dateutil in generated client #298

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `setup` will generate a pyproject.toml with no Poetry information, and instead create a `setup.py` with the 
     project info.
   - `none` will not create a project folder at all, only the inner package folder (which won't be inner anymore)
-  - Lowered the minimum version of `python-dateutil` for improved dependency compatibility with other projects
+- Lowered the minimum version of `python-dateutil` for improved dependency compatibility with other projects
 
 
 ## 0.7.3 - 2020-12-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `setup` will generate a pyproject.toml with no Poetry information, and instead create a `setup.py` with the 
     project info.
   - `none` will not create a project folder at all, only the inner package folder (which won't be inner anymore)
+  - Lowered the minimum version of `python-dateutil` for improved dependency compatibility with other projects
 
 
 ## 0.7.3 - 2020-12-21

--- a/end_to_end_tests/golden-record-custom/pyproject.toml
+++ b/end_to_end_tests/golden-record-custom/pyproject.toml
@@ -16,7 +16,7 @@ include = ["CHANGELOG.md", "custom_e2e/py.typed"]
 python = "^3.6"
 httpx = ">=0.15.4,<0.17.0"
 attrs = "^20.1.0"
-python-dateutil = "^2.8.1"
+python-dateutil = "^2.8.0"
 
 [tool.black]
 line-length = 120

--- a/end_to_end_tests/golden-record/pyproject.toml
+++ b/end_to_end_tests/golden-record/pyproject.toml
@@ -16,7 +16,7 @@ include = ["CHANGELOG.md", "my_test_api_client/py.typed"]
 python = "^3.6"
 httpx = ">=0.15.4,<0.17.0"
 attrs = "^20.1.0"
-python-dateutil = "^2.8.1"
+python-dateutil = "^2.8.0"
 
 [tool.black]
 line-length = 120

--- a/openapi_python_client/templates/pyproject.toml
+++ b/openapi_python_client/templates/pyproject.toml
@@ -16,7 +16,7 @@ include = ["CHANGELOG.md", "{{ package_name }}/py.typed"]
 python = "^3.6"
 httpx = ">=0.15.4,<0.17.0"
 attrs = "^20.1.0"
-python-dateutil = "^2.8.1"
+python-dateutil = "^2.8.0"
 
 [tool.black]
 line-length = 120

--- a/openapi_python_client/templates/setup.py
+++ b/openapi_python_client/templates/setup.py
@@ -14,6 +14,6 @@ setup(
     package_dir={"": "{{ package_name }}"},
     packages=find_packages(where="{{ package_name }}"),
     python_requires=">=3.6, <4",
-    install_requires=["httpx >= 0.15.0, < 0.17.0", "attrs >= 20.1.0", "python-dateutil >= 2.8.1, < 3"],
+    install_requires=["httpx >= 0.15.0, < 0.17.0", "attrs >= 20.1.0", "python-dateutil >= 2.8.0, < 3"],
     package_data={"": ["CHANGELOG.md"], "{{ package_name }}": ["py.typed"]},
 )


### PR DESCRIPTION
The generated client now features a slightly more permissive version of `python-dateutil` to reduce dependency conflicts with some other projects. #298 