### PR TITLE
Prefer property name instead of title for class name

### DIFF
--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -302,7 +302,7 @@ def build_model_property(
         name=name,
         additional_properties=additional_properties,
     )
-    schemas = attr.evolve(schemas, models={**schemas.models, prop.reference.class_name: prop})
+    schemas = attr.evolve(schemas, models={**schemas.models, prop.name: prop})
     return prop, schemas
 
 
@@ -374,7 +374,7 @@ def build_enum_property(
         values=values,
         value_type=value_type,
     )
-    schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
+    schemas = attr.evolve(schemas, enums={**schemas.enums, prop.name: prop})
     return prop, schemas
 
 

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -510,7 +510,7 @@ class TestPropertyFromData:
         assert schemas != new_schemas, "Provided Schemas was mutated"
         assert new_schemas.enums == {
             "AnEnum": schemas.enums["AnEnum"],
-            "ParentAnEnum": prop,
+            "my_enum": prop,
         }
 
     def test_property_from_data_int_enum(self, mocker):
@@ -541,7 +541,7 @@ class TestPropertyFromData:
         assert schemas != new_schemas, "Provided Schemas was mutated"
         assert new_schemas.enums == {
             "AnEnum": schemas.enums["AnEnum"],
-            "ParentAnEnum": prop,
+            "my_enum": prop,
         }
 
     def test_property_from_data_ref_enum(self):
@@ -1083,7 +1083,7 @@ def test_build_model_property(additional_properties_schema, expected_additional_
     assert new_schemas != schemas
     assert new_schemas.models == {
         "OtherModel": None,
-        "ParentMyModel": model,
+        "prop": model,
     }
     assert model == ModelProperty(
         name="prop",


### PR DESCRIPTION
When the title of a schema object doesn't match its property name, reference resolution breaks. Simplest demonstration:
```python
#!/usr/bin/env python3
from typing import Generic, TypeVar
from pydantic import BaseModel
from pydantic.generics import GenericModel
from fastapi import FastAPI

app = FastAPI()

T = TypeVar('T')

class GenericItem(GenericModel, Generic[T]):
    prop: T

@app.get("/int_item", response_model=GenericItem[int])
def get_int_item():
    return GenericItem[int](prop=88)
```

This will cause the client to produce a warning:
```
Warning(s) encountered while generating. Client was generated, but some pieces may be missing

WARNING parsing GET /int_item within default.

Cannot parse response for status code 200, response will be ommitted from generated client

Reference(ref='#/components/schemas/GenericItem_int_')
```
This pull request fixes this by prefering the property name as the class name for a model over its title.