### PR TITLE
Avoid attributes named "self"

### DIFF
--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -15,7 +15,7 @@ def fix_keywords(value: str) -> str:
     return value
 
 
-RESERVED_WORDS = ('self')
+RESERVED_WORDS = ("self",)
 
 
 def fix_reserved_words(value: str) -> str:

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -15,6 +15,15 @@ def fix_keywords(value: str) -> str:
     return value
 
 
+RESERVED_WORDS = ('self')
+
+
+def fix_reserved_words(value: str) -> str:
+    if value in RESERVED_WORDS:
+        return f"{value}_"
+    return value
+
+
 def group_title(value: str) -> str:
     value = re.sub(r"([A-Z]{2,})([A-Z][a-z]|[ \-_]|$)", lambda m: m.group(1).title() + m.group(2), value.strip())
     value = re.sub(r"(^|[ _-])([A-Z])", lambda m: m.group(1) + m.group(2).lower(), value)
@@ -49,7 +58,7 @@ def to_valid_python_identifier(value: str) -> str:
     See:
         https://docs.python.org/3/reference/lexical_analysis.html#identifiers
     """
-    new_value = fix_keywords(sanitize(value))
+    new_value = fix_reserved_words(fix_keywords(sanitize(value)))
 
     if new_value.isidentifier():
         return new_value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,10 @@ def test__fix_keywords():
     assert utils.fix_keywords("None") == "None_"
 
 
+def test__fix_reserved_words():
+    assert utils.fix_reserved_words("self") == "self_"
+
+
 def test_to_valid_python_identifier():
     assert utils.to_valid_python_identifier("valid") == "valid"
     assert utils.to_valid_python_identifier("1") == "field_1"


### PR DESCRIPTION
I'm currently working with an api that uses [json:api](http://jsonapi.org). This uses a "self" attribute a lot. `python-attrs` fails to create an __init__ function for this because of a name collision on `self`. Although `self` is not a keyword in python, it's probably a good idea to not allow `self` as an attribute name. Alternatively, you could try to convince the folks developing `python-attrs` to allow for a `self` attribute by using a different name for the `self` parameter internally, like `pydantic` does.
This is a quick fix to just create a `self_` attribute instead.