### PR TITLE
Handle Unset Enums when deserializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     project info.
   - `none` will not create a project folder at all, only the inner package folder (which won't be inner anymore)
 - Attempt to detect and alert users if they are using an unsupported version of OpenAPI (#281).
+- Fixes `Enum` deserialization when the value is `UNSET`.
 
 ### Changes
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_union_property.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_union_property.py
@@ -46,7 +46,7 @@ class ModelWithUnionProperty:
             try:
                 a_property = UNSET
                 _a_property = data
-                if _a_property is not None:
+                if _a_property is not None and _a_property is not UNSET:
                     a_property = AnEnum(_a_property)
 
                 return a_property
@@ -54,7 +54,7 @@ class ModelWithUnionProperty:
                 pass
             a_property = UNSET
             _a_property = data
-            if _a_property is not None:
+            if _a_property is not None and _a_property is not UNSET:
                 a_property = AnIntEnum(_a_property)
 
             return a_property

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_union_property.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_union_property.py
@@ -46,7 +46,7 @@ class ModelWithUnionProperty:
             try:
                 a_property = UNSET
                 _a_property = data
-                if _a_property is not None:
+                if _a_property is not None and _a_property is not UNSET:
                     a_property = AnEnum(_a_property)
 
                 return a_property
@@ -54,7 +54,7 @@ class ModelWithUnionProperty:
                 pass
             a_property = UNSET
             _a_property = data
-            if _a_property is not None:
+            if _a_property is not None and _a_property is not UNSET:
                 a_property = AnIntEnum(_a_property)
 
             return a_property

--- a/openapi_python_client/templates/property_templates/enum_property.pyi
+++ b/openapi_python_client/templates/property_templates/enum_property.pyi
@@ -4,7 +4,7 @@
 {% else %}
 {{ property.python_name }} = {{ initial_value }}
 _{{ property.python_name }} = {{ source }}
-if _{{ property.python_name }} is not None:
+if _{{ property.python_name }} is not None and _{{ property.python_name }} is not UNSET:
     {{ property.python_name }} = {{ property.reference.class_name }}(_{{ property.python_name }})
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
When an `Enum` is `Unset` during deserialization, it causes an error by attempting to instantiate it from `UNSET`.