### PR TITLE
Add "application/vnd.api+json" media type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `none` will not create a project folder at all, only the inner package folder (which won't be inner anymore)
 - Attempt to detect and alert users if they are using an unsupported version of OpenAPI (#281).
 - Fixes `Enum` deserialization when the value is `UNSET`.
+- Add handling of application/vnd.api+json media type.
 
 ### Changes
 

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -20,6 +20,7 @@ class Response:
 
 _SOURCE_BY_CONTENT_TYPE = {
     "application/json": "response.json()",
+    "application/vnd.api+json": "response.json()",
     "application/octet-stream": "response.content",
     "text/html": "response.text",
 }


### PR DESCRIPTION
[JSON:API](https://jsonapi.org/format/) has a media type of [application/vnd.api+json](https://www.iana.org/assignments/media-types/application/vnd.api+json), which is just json, so it can be parsed as such. This pull request adds it to the list of parsable media types.