### PR TITLE
Fix/softly-ignore-invalid-response-status-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- Parser will softly ignore value error during schema responses' status code convertion from string to integer (not a number). Errors will be reported to the end user and parsing will continue to proceed (#327).
 - The generated `from_dict` and `to_dict` methods of models will now properly handle `nullable` and `not required` properties that are themselves generated models (#315). Thanks @forest-benchling!
 
 ## 0.7.3 - 2020-12-21

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -169,14 +169,29 @@ class Endpoint:
     def _add_responses(*, endpoint: "Endpoint", data: oai.Responses, schemas: Schemas) -> Tuple["Endpoint", Schemas]:
         endpoint = deepcopy(endpoint)
         for code, response_data in data.items():
+
+            status_code: int
+            try:
+                status_code = int(code)
+            except ValueError:
+                endpoint.errors.append(
+                    ParseError(
+                        detail=(
+                            f"Invalid response status code {code} (not a number), "
+                            f"response will be ommitted from generated client"
+                        )
+                    )
+                )
+                continue
+
             response, schemas = response_from_data(
-                status_code=int(code), data=response_data, schemas=schemas, parent_name=endpoint.name
+                status_code=status_code, data=response_data, schemas=schemas, parent_name=endpoint.name
             )
             if isinstance(response, ParseError):
                 endpoint.errors.append(
                     ParseError(
                         detail=(
-                            f"Cannot parse response for status code {code}, "
+                            f"Cannot parse response for status code {status_code}, "
                             f"response will be ommitted from generated client"
                         ),
                         data=response.data,

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -294,6 +294,35 @@ class TestEndpoint:
         assert endpoint.form_body_reference == form_body_reference
         assert endpoint.multipart_body_reference == multipart_body_reference
 
+    def test__add_responses_status_code_error(self, mocker):
+        from openapi_python_client.parser.openapi import Endpoint, Schemas
+
+        schemas = Schemas()
+        response_1_data = mocker.MagicMock()
+        response_2_data = mocker.MagicMock()
+        data = {
+            "not_a_number": response_1_data,
+        }
+        endpoint = Endpoint(
+            path="path",
+            method="method",
+            description=None,
+            name="name",
+            requires_security=False,
+            tag="tag",
+            relative_imports={"import_3"},
+        )
+        parse_error = ParseError(data=mocker.MagicMock())
+        response_from_data = mocker.patch(f"{MODULE_NAME}.response_from_data", return_value=(parse_error, schemas))
+
+        response, schemas = Endpoint._add_responses(endpoint=endpoint, data=data, schemas=schemas)
+
+        assert response.errors == [
+            ParseError(
+                detail=f"Invalid response status code not_a_number (not a number), response will be ommitted from generated client"
+            )
+        ]
+
     def test__add_responses_error(self, mocker):
         from openapi_python_client.parser.openapi import Endpoint, Schemas
 


### PR DESCRIPTION
####  Title
Fix/softly-ignore-invalid-response-status-code

#### Description
This PR will make the parser softly ignore responses' invalid status code (not a number). It catch the `ValueError` exception, inform the end user and continue its processing.

#### QA Notes & Product impact
The `ValueError` exception raised when a response's status code is not a valid number won't be propagated anymore.
@dbanty