### PR TITLE
Feature/add-properties-local-reference-support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
+- Add support for properties local reference ($ref) resolution
 - New `--meta` command line option for specifying what type of metadata should be generated:
   - `poetry` is the default value, same behavior you're used to in previous versions
   - `setup` will generate a pyproject.toml with no Poetry information, and instead create a `setup.py` with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
-- Add support for properties local reference ($ref) resolution
+- Add support of properties indirect reference ($ref) resolution; Add support of inner properties direct and indirect reference resolution to its owner model/enum (#329). Thanks @p1-ra!
 - New `--meta` command line option for specifying what type of metadata should be generated:
   - `poetry` is the default value, same behavior you're used to in previous versions
   - `setup` will generate a pyproject.toml with no Poetry information, and instead create a `setup.py` with the

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model.py
@@ -27,6 +27,9 @@ class AModel:
     a_nullable_date: Optional[datetime.date]
     required_nullable: Optional[str]
     nullable_model: Optional[AModelNullableModel]
+    an_enum_indirect_ref: Union[Unset, AnEnum] = UNSET
+    direct_ref_to_itself: Union["AModel", Unset] = UNSET
+    indirect_ref_to_itself: Union["AModel", Unset] = UNSET
     nested_list_of_enums: Union[Unset, List[List[DifferentEnum]]] = UNSET
     a_not_required_date: Union[Unset, datetime.date] = UNSET
     attr_1_leading_digit: Union[Unset, str] = UNSET
@@ -47,6 +50,18 @@ class AModel:
         a_date = self.a_date.isoformat()
         required_not_nullable = self.required_not_nullable
         model = self.model.to_dict()
+
+        an_enum_indirect_ref: Union[Unset, AnEnum] = UNSET
+        if not isinstance(self.an_enum_indirect_ref, Unset):
+            an_enum_indirect_ref = self.an_enum_indirect_ref
+
+        direct_ref_to_itself: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.direct_ref_to_itself, Unset):
+            direct_ref_to_itself = self.direct_ref_to_itself.to_dict()
+
+        indirect_ref_to_itself: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.indirect_ref_to_itself, Unset):
+            indirect_ref_to_itself = self.indirect_ref_to_itself.to_dict()
 
         nested_list_of_enums: Union[Unset, List[Any]] = UNSET
         if not isinstance(self.nested_list_of_enums, Unset):
@@ -94,6 +109,12 @@ class AModel:
                 "nullable_model": nullable_model,
             }
         )
+        if an_enum_indirect_ref is not UNSET:
+            field_dict["an_enum_indirect_ref"] = an_enum_indirect_ref
+        if direct_ref_to_itself is not UNSET:
+            field_dict["direct_ref_to_itself"] = direct_ref_to_itself
+        if indirect_ref_to_itself is not UNSET:
+            field_dict["indirect_ref_to_itself"] = indirect_ref_to_itself
         if nested_list_of_enums is not UNSET:
             field_dict["nested_list_of_enums"] = nested_list_of_enums
         if a_not_required_date is not UNSET:
@@ -136,6 +157,21 @@ class AModel:
         required_not_nullable = d.pop("required_not_nullable")
 
         model = AModelModel.from_dict(d.pop("model"))
+
+        an_enum_indirect_ref: Union[Unset, AnEnum] = UNSET
+        _an_enum_indirect_ref = d.pop("an_enum_indirect_ref", UNSET)
+        if not isinstance(_an_enum_indirect_ref, Unset):
+            an_enum_indirect_ref = AnEnum(_an_enum_indirect_ref)
+
+        direct_ref_to_itself: Union[AModel, Unset] = UNSET
+        _direct_ref_to_itself = d.pop("direct_ref_to_itself", UNSET)
+        if not isinstance(_direct_ref_to_itself, Unset):
+            direct_ref_to_itself = AModel.from_dict(_direct_ref_to_itself)
+
+        indirect_ref_to_itself: Union[AModel, Unset] = UNSET
+        _indirect_ref_to_itself = d.pop("indirect_ref_to_itself", UNSET)
+        if not isinstance(_indirect_ref_to_itself, Unset):
+            indirect_ref_to_itself = AModel.from_dict(_indirect_ref_to_itself)
 
         nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
@@ -188,6 +224,9 @@ class AModel:
             a_date=a_date,
             required_not_nullable=required_not_nullable,
             model=model,
+            an_enum_indirect_ref=an_enum_indirect_ref,
+            direct_ref_to_itself=direct_ref_to_itself,
+            indirect_ref_to_itself=indirect_ref_to_itself,
             nested_list_of_enums=nested_list_of_enums,
             a_nullable_date=a_nullable_date,
             a_not_required_date=a_not_required_date,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
@@ -27,6 +27,9 @@ class AModel:
     a_nullable_date: Optional[datetime.date]
     required_nullable: Optional[str]
     nullable_model: Optional[AModelNullableModel]
+    an_enum_indirect_ref: Union[Unset, AnEnum] = UNSET
+    direct_ref_to_itself: Union["AModel", Unset] = UNSET
+    indirect_ref_to_itself: Union["AModel", Unset] = UNSET
     nested_list_of_enums: Union[Unset, List[List[DifferentEnum]]] = UNSET
     a_not_required_date: Union[Unset, datetime.date] = UNSET
     attr_1_leading_digit: Union[Unset, str] = UNSET
@@ -47,6 +50,18 @@ class AModel:
         a_date = self.a_date.isoformat()
         required_not_nullable = self.required_not_nullable
         model = self.model.to_dict()
+
+        an_enum_indirect_ref: Union[Unset, AnEnum] = UNSET
+        if not isinstance(self.an_enum_indirect_ref, Unset):
+            an_enum_indirect_ref = self.an_enum_indirect_ref
+
+        direct_ref_to_itself: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.direct_ref_to_itself, Unset):
+            direct_ref_to_itself = self.direct_ref_to_itself.to_dict()
+
+        indirect_ref_to_itself: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.indirect_ref_to_itself, Unset):
+            indirect_ref_to_itself = self.indirect_ref_to_itself.to_dict()
 
         nested_list_of_enums: Union[Unset, List[Any]] = UNSET
         if not isinstance(self.nested_list_of_enums, Unset):
@@ -94,6 +109,12 @@ class AModel:
                 "nullable_model": nullable_model,
             }
         )
+        if an_enum_indirect_ref is not UNSET:
+            field_dict["an_enum_indirect_ref"] = an_enum_indirect_ref
+        if direct_ref_to_itself is not UNSET:
+            field_dict["direct_ref_to_itself"] = direct_ref_to_itself
+        if indirect_ref_to_itself is not UNSET:
+            field_dict["indirect_ref_to_itself"] = indirect_ref_to_itself
         if nested_list_of_enums is not UNSET:
             field_dict["nested_list_of_enums"] = nested_list_of_enums
         if a_not_required_date is not UNSET:
@@ -136,6 +157,21 @@ class AModel:
         required_not_nullable = d.pop("required_not_nullable")
 
         model = AModelModel.from_dict(d.pop("model"))
+
+        an_enum_indirect_ref: Union[Unset, AnEnum] = UNSET
+        _an_enum_indirect_ref = d.pop("an_enum_indirect_ref", UNSET)
+        if not isinstance(_an_enum_indirect_ref, Unset):
+            an_enum_indirect_ref = AnEnum(_an_enum_indirect_ref)
+
+        direct_ref_to_itself: Union[AModel, Unset] = UNSET
+        _direct_ref_to_itself = d.pop("direct_ref_to_itself", UNSET)
+        if not isinstance(_direct_ref_to_itself, Unset):
+            direct_ref_to_itself = AModel.from_dict(_direct_ref_to_itself)
+
+        indirect_ref_to_itself: Union[AModel, Unset] = UNSET
+        _indirect_ref_to_itself = d.pop("indirect_ref_to_itself", UNSET)
+        if not isinstance(_indirect_ref_to_itself, Unset):
+            indirect_ref_to_itself = AModel.from_dict(_indirect_ref_to_itself)
 
         nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
@@ -188,6 +224,9 @@ class AModel:
             a_date=a_date,
             required_not_nullable=required_not_nullable,
             model=model,
+            an_enum_indirect_ref=an_enum_indirect_ref,
+            direct_ref_to_itself=direct_ref_to_itself,
+            indirect_ref_to_itself=indirect_ref_to_itself,
             nested_list_of_enums=nested_list_of_enums,
             a_nullable_date=a_nullable_date,
             a_not_required_date=a_not_required_date,

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -675,6 +675,15 @@
         "required": ["an_enum_value", "aCamelDateTime", "a_date", "a_nullable_date", "required_nullable", "required_not_nullable", "model", "nullable_model"],
         "type": "object",
         "properties": {
+          "an_enum_indirect_ref": {
+            "$ref": "#/components/schemas/AnEnumDeeperIndirectReference"
+          },
+          "direct_ref_to_itself": {
+            "$ref": "#/components/schemas/AModel"
+          },
+          "indirect_ref_to_itself": {
+            "$ref": "#/components/schemas/AModelDeeperIndirectReference"
+          },
           "an_enum_value": {
             "$ref": "#/components/schemas/AnEnum"
           },
@@ -716,7 +725,7 @@
           "a_not_required_date": {
             "title": "A Nullable Date",
             "type": "string",
-            "format": "date",
+            "format": "date"
           },
           "1_leading_digit": {
             "title": "Leading Digit",
@@ -782,10 +791,22 @@
         "description": "A Model for testing all the ways custom objects can be used ",
         "additionalProperties": false
       },
+      "AModelIndirectReference": {
+        "$ref": "#/components/schemas/AModel"
+      },
+      "AModelDeeperIndirectReference": {
+        "$ref": "#/components/schemas/AModelIndirectReference"
+      },
+      "AnEnumIndirectReference": {
+       "$ref": "#/components/schemas/AnEnum" 
+      },
       "AnEnum": {
         "title": "AnEnum",
         "enum": ["FIRST_VALUE", "SECOND_VALUE"],
         "description": "For testing Enums in all the ways they can be used "
+      },
+      "AnEnumDeeperIndirectReference": {
+        "$ref": "#/components/schemas/AnEnumIndirectReference" 
       },
       "AnIntEnum": {
         "title": "AnIntEnum",

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -811,11 +811,8 @@ def build_schemas(*, components: Dict[str, Union[oai.Reference, oai.Schema]]) ->
             visited.append(name)
 
             if isinstance(data, oai.Reference):
-                class_name = _reference_model_name(data)
-
-                if not schemas.models.get(class_name) and not schemas.enums.get(class_name):
-                    references_by_name[name] = data
-                    references_to_process.append((name, data))
+                references_by_name[name] = data
+                references_to_process.append((name, data))
                 continue
 
             schemas_or_err = update_schemas_with_data(name, data, schemas, lazy_self_references)

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -63,6 +63,11 @@ class LazyReferencePropertyProxy:
             return resolved.get_imports(prefix=prefix)
         return set()
 
+    def to_string(self) -> str:
+        resolved = cast(Property, self.resolve(False))
+        p_repr = resolved.to_string()
+        return p_repr.replace(f"{self._parent_name}", f"'{self._parent_name}'")
+
     def __copy__(self) -> Property:
         resolved = cast(Property, self.resolve(False))
         return copy.copy(resolved)

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -574,12 +574,12 @@ def _property_from_data(
                 ref_name: str, owner_class_name: str, lazy_references: Dict[str, oai.Reference]
             ) -> bool:
                 if ref_name in lazy_references:
-                    next_ref_name = _reference_name(lazy_references[ref_name])
+                    next_ref_name = _reference_pointer_name(lazy_references[ref_name])
                     return lookup_is_reference_to_itself(next_ref_name, owner_class_name, lazy_references)
 
                 return ref_name.casefold() == owner_class_name.casefold()
 
-            reference_name = _reference_name(data)
+            reference_name = _reference_pointer_name(data)
             if lookup_is_reference_to_itself(reference_name, parent_name, lazy_references):
                 return cast(Property, LazyReferencePropertyProxy.create(name, required, data, parent_name)), schemas
             else:
@@ -740,7 +740,7 @@ def _resolve_model_or_enum_reference(
     name: str, data: oai.Reference, schemas: Schemas, references_by_name: Dict[str, oai.Reference]
 ) -> Union[EnumProperty, ModelProperty, None]:
     target_model = _reference_model_name(data)
-    target_name = _reference_name(data)
+    target_name = _reference_pointer_name(data)
 
     if target_model == name or target_name == name:
         return None  # Avoid infinite loop
@@ -772,7 +772,7 @@ def _reference_model_name(reference: oai.Reference) -> str:
     return Reference.from_ref(reference.ref).class_name
 
 
-def _reference_name(reference: oai.Reference) -> str:
+def _reference_pointer_name(reference: oai.Reference) -> str:
     parts = reference.ref.split("/")
     return parts[-1]
 
@@ -822,7 +822,7 @@ def build_schemas(*, components: Dict[str, Union[oai.Reference, oai.Schema]]) ->
             schemas_or_err = resolve_reference_and_update_schemas(name, reference, schemas, references_by_name)
 
             if isinstance(schemas_or_err, PropertyError):
-                if _reference_name(reference) in visited:
+                if _reference_pointer_name(reference) in visited:
                     # It's a reference to an already visited Enum|Model; not yet resolved
                     # It's an indirect reference toward this Enum|Model;
                     # It will be lazy proxified and resolved later on

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -78,7 +78,7 @@ class LazyReferencePropertyProxy:
 
     def __getattr__(self, name: str) -> Any:
         if name == "nullable":
-            return not self._required
+            return False
         elif name == "required":
             return self._required
         else:

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -670,7 +670,7 @@ def _is_local_reference(reference: oai.Reference) -> bool:
 
 
 def _reference_model_name(reference: oai.Reference) -> str:
-    return utils.pascal_case(_reference_name(reference))
+    return Reference.from_ref(reference.ref).class_name
 
 
 def _reference_name(reference: oai.Reference) -> str:

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -548,7 +548,7 @@ class TestPropertyFromData:
         from openapi_python_client.parser.properties import EnumProperty, Reference, Schemas, property_from_data
 
         name = "some_enum"
-        data = oai.Reference.construct(ref="MyEnum")
+        data = oai.Reference.construct(ref="#MyEnum")
         existing_enum = EnumProperty(
             name="an_enum",
             required=True,
@@ -579,7 +579,7 @@ class TestPropertyFromData:
         name = "new_name"
         required = False
         class_name = "MyModel"
-        data = oai.Reference.construct(ref=class_name)
+        data = oai.Reference.construct(ref=f"#{class_name}")
         existing_model = ModelProperty(
             name="old_name",
             required=True,

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -1513,7 +1513,7 @@ def test_lazy_proxy_reference_unresolved():
     assert lazy_reference_proxy.get_imports(prefix="..") == set()
     assert lazy_reference_proxy.resolve() == None
     assert lazy_reference_proxy.required == False
-    assert lazy_reference_proxy.nullable == True
+    assert lazy_reference_proxy.nullable == False
     with pytest.raises(RuntimeError):
         lazy_reference_proxy.resolve(False)
     with pytest.raises(RuntimeError):

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -1705,6 +1705,6 @@ components:
 
     assert len(schemas.errors) == 1
     assert schemas.errors[0] == PropertyError(
-        detail="Could not find reference in parsed models or enums.",
+        detail="invalid data in items of array childSettings",
         data=oai.Reference(ref="#/components/schemas/noexist"),
     )


### PR DESCRIPTION
####  Title
Feature/add-properties-local-reference-support

#### Description
This PR aims to bring support of properties local references resolution. It could happen that in a Document a local reference is pointing to one or multiple other _virtual_ references instead to its property definition, as for exemple: 

```
(...)
    ModelWithAnyJsonProperties:
      title: ModelWithAnyJsonProperties
      type: object
      additionalProperties:
        anyOf:
        - type: object
          additionalProperties:
            type: string
        - type: array
          items:
            type: string
        - type: string
        - type: number
        - type: integer
        - type: boolean
    ModelLocalReferenceLoop:
      "$ref": "#/components/schemas/ModelWithAnyJsonProperties"
    ModelDeeperLocalReferenceLoop:
      "$ref": "#/components/schemas/ModelLocalReferenceLoop"
 (...)
 ```
 
 During properties parsing, those _virtual_ reference are resolved by making them pointing to their target `ModelProperty` or `EnumProperty` definition.
 
 Thus, only the target model will be generated and any path referencing them _(the virtual reference)_  will use the target model.

Also add support for inner property direct and indirect reference to its parent model resolution, as:
```
(...)
AModel:
  title: AModel
  type: object
  properties:
    direct_ref_to_itself:
      $ref: '#/components/schemas/AModel'
    indirect_ref_to_itself:
      $ref: '#/components/schemas/AModelDeeperIndirectReference'
AModelIndirectReference:
  $ref: '#/components/schemas/AModel'
AModelDeeperIndirectReference:
  $ref: '#/components/schemas/AModelIndirectReference'
(...)
```

#### QA Notes & Product impact
Add support for properties local reference ($ref) resolution
Add support for inner property direct and indirect reference to its parent model resolution.

@dbanty