### PR TITLE
fix: Fail when duplicate names are generated

### DIFF
--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -806,6 +806,29 @@
         },
         "additionalProperties": false
       },
+      "ModelWithUnionPropertyInlined": {
+        "title": "ModelWithUnionPropertyInlined",
+        "type": "object",
+        "properties": {
+          "fruit": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "apples": {"type": "string"}
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "bananas": {"type": "string"}
+                }
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "FreeFormModel": {
         "title": "FreeFormModel",
         "type": "object"

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -806,29 +806,6 @@
         },
         "additionalProperties": false
       },
-      "ModelWithUnionPropertyInlined": {
-        "title": "ModelWithUnionPropertyInlined",
-        "type": "object",
-        "properties": {
-          "fruit": {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "apples": {"type": "string"}
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "bananas": {"type": "string"}
-                }
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
       "FreeFormModel": {
         "title": "FreeFormModel",
         "type": "object"

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -303,12 +303,12 @@ def build_model_property(
         additional_properties=additional_properties,
     )
     if prop.reference.class_name in schemas.models:
-        prop = PropertyError(
-            data=data,
-            detail=f'Attempted to generate duplicate models with name "{prop.reference.class_name}"')
-    else:
-        schemas = attr.evolve(schemas, models={**schemas.models, prop.reference.class_name: prop})
+        error = PropertyError(
+            data=data, detail=f'Attempted to generate duplicate models with name "{prop.reference.class_name}"'
+        )
+        return error, schemas
 
+    schemas = attr.evolve(schemas, models={**schemas.models, prop.reference.class_name: prop})
     return prop, schemas
 
 
@@ -381,12 +381,12 @@ def build_enum_property(
         value_type=value_type,
     )
     if prop.reference.class_name in schemas.enums:
-        prop = PropertyError(
-            data=data,
-            detail=f'Attempted to generate duplicate enums with name "{prop.reference.class_name}"')
-    else:
-        schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
+        error = PropertyError(
+            data=data, detail=f'Attempted to generate duplicate enums with name "{prop.reference.class_name}"'
+        )
+        return error, schemas
 
+    schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
     return prop, schemas
 
 

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -380,7 +380,6 @@ def build_enum_property(
         values=values,
         value_type=value_type,
     )
-
     schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
     return prop, schemas
 

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -234,10 +234,6 @@ def _string_based_property(
         )
 
 
-class NameClashException(Exception):
-    pass
-
-
 def build_model_property(
     *, data: oai.Schema, name: str, schemas: Schemas, required: bool, parent_name: Optional[str]
 ) -> Tuple[Union[ModelProperty, PropertyError], Schemas]:
@@ -307,9 +303,12 @@ def build_model_property(
         additional_properties=additional_properties,
     )
     if prop.reference.class_name in schemas.models:
-        raise NameClashException(f'Attempted to generate duplicate models with name "{prop.reference.class_name}"')
+        prop = PropertyError(
+            data=data,
+            detail=f'Attempted to generate duplicate models with name "{prop.reference.class_name}"')
+    else:
+        schemas = attr.evolve(schemas, models={**schemas.models, prop.reference.class_name: prop})
 
-    schemas = attr.evolve(schemas, models={**schemas.models, prop.reference.class_name: prop})
     return prop, schemas
 
 
@@ -382,9 +381,12 @@ def build_enum_property(
         value_type=value_type,
     )
     if prop.reference.class_name in schemas.enums:
-        raise NameClashException(f'Attempted to generate duplicate enums with name "{prop.reference.class_name}"')
+        prop = PropertyError(
+            data=data,
+            detail=f'Attempted to generate duplicate enums with name "{prop.reference.class_name}"')
+    else:
+        schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
 
-    schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
     return prop, schemas
 
 

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -234,6 +234,10 @@ def _string_based_property(
         )
 
 
+class NameClashException(Exception):
+    pass
+
+
 def build_model_property(
     *, data: oai.Schema, name: str, schemas: Schemas, required: bool, parent_name: Optional[str]
 ) -> Tuple[Union[ModelProperty, PropertyError], Schemas]:
@@ -302,6 +306,9 @@ def build_model_property(
         name=name,
         additional_properties=additional_properties,
     )
+    if prop.reference.class_name in schemas.models:
+        raise NameClashException(f'Attempted to generate duplicate models with name "{prop.reference.class_name}"')
+
     schemas = attr.evolve(schemas, models={**schemas.models, prop.reference.class_name: prop})
     return prop, schemas
 
@@ -374,6 +381,9 @@ def build_enum_property(
         values=values,
         value_type=value_type,
     )
+    if prop.reference.class_name in schemas.enums:
+        raise NameClashException(f'Attempted to generate duplicate enums with name "{prop.reference.class_name}"')
+
     schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
     return prop, schemas
 

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -380,11 +380,6 @@ def build_enum_property(
         values=values,
         value_type=value_type,
     )
-    if prop.reference.class_name in schemas.enums:
-        error = PropertyError(
-            data=data, detail=f'Attempted to generate duplicate enums with name "{prop.reference.class_name}"'
-        )
-        return error, schemas
 
     schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
     return prop, schemas

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -1147,6 +1147,7 @@ def test_build_model_property_bad_prop(mocker):
         required=True,
         parent_name=None,
     )
+
     assert new_schemas == schemas
     assert err == PropertyError(detail="unknown type not_real", data=oai.Schema(type="not_real"))
 

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -1105,7 +1105,32 @@ def test_build_model_property(additional_properties_schema, expected_additional_
     )
 
 
-def test_build_model_property_bad_prop():
+def test_build_model_property_conflict():
+    from openapi_python_client.parser.properties import Schemas, build_model_property
+
+    data = oai.Schema.construct(
+        required=["req"],
+        properties={
+            "req": oai.Schema.construct(type="string"),
+            "opt": oai.Schema(type="string", format="date-time"),
+        },
+        nullable=False,
+    )
+    schemas = Schemas(models={"OtherModel": None})
+
+    err, new_schemas = build_model_property(
+        data=data,
+        name="OtherModel",
+        schemas=schemas,
+        required=True,
+        parent_name=None,
+    )
+
+    assert new_schemas == schemas
+    assert err == PropertyError(detail='Attempted to generate duplicate models with name "OtherModel"', data=data)
+
+
+def test_build_model_property_bad_prop(mocker):
     from openapi_python_client.parser.properties import Schemas, build_model_property
 
     data = oai.Schema(
@@ -1122,7 +1147,6 @@ def test_build_model_property_bad_prop():
         required=True,
         parent_name=None,
     )
-
     assert new_schemas == schemas
     assert err == PropertyError(detail="unknown type not_real", data=oai.Schema(type="not_real"))
 

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -1130,7 +1130,7 @@ def test_build_model_property_conflict():
     assert err == PropertyError(detail='Attempted to generate duplicate models with name "OtherModel"', data=data)
 
 
-def test_build_model_property_bad_prop(mocker):
+def test_build_model_property_bad_prop():
     from openapi_python_client.parser.properties import Schemas, build_model_property
 
     data = oai.Schema(


### PR DESCRIPTION
Previously, it would silently create buggy code if duplicate models were generated with the same name; see https://github.com/triaxtec/openapi-python-client/pull/335 and https://github.com/triaxtec/openapi-python-client/issues/323.