### PR TITLE
Fix/template-duplicate-return-type

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -61,6 +61,10 @@ def _parse_response(*, response: httpx.Response) -> Optional[Union[List[AModel],
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+    if response.status_code == 423:
+        response_423 = HTTPValidationError.from_dict(response.json())
+
+        return response_423
     return None
 
 

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -70,6 +70,16 @@
                 }
               }
             }
+          },
+          "423": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
         }
       }

--- a/openapi_python_client/templates/endpoint_macros.py.jinja
+++ b/openapi_python_client/templates/endpoint_macros.py.jinja
@@ -71,6 +71,12 @@ params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 {% endif %}
 {% endmacro %}
 
+{% macro reponses_type_csv(responses) %}
+{% for response in responses %}
+{{ response.prop.get_type_string() }}{{"," if not loop.last }}
+{% endfor %}
+{% endmacro %}
+
 {% macro return_type(endpoint) %}
 {% if endpoint.responses | length == 0 %}
 None
@@ -78,8 +84,9 @@ None
 {{ endpoint.responses[0].prop.get_type_string() }}
 {%- else %}
 Union[
-    {% for response in endpoint.responses %}
-    {{ response.prop.get_type_string() }}{{ "," if not loop.last }}
+    {% set response_types = reponses_type_csv(endpoint.responses) | trim  %}
+    {% for type_string in (response_types.split(',') | unique | list) %}
+    {{ type_string }}{{ "," if not loop.last }}
     {% endfor %}
 ]
 {%- endif %}


### PR DESCRIPTION
####  Title
Fix/template-duplicate-return-type

### Description
Add a tiny fix on the endpoint template `return_type` macro, it ensure the unicity of the models' type.
When an endpoint  use the same reference model for multiple responses (code), the model type was duplicated in function return types anotation.

Modified golden records diff before the fix:
```
diff --git a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
index ec22168..2e3a558 100644
--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -47,7 +47,9 @@ def _get_kwargs(
     }


-def _parse_response(*, response: httpx.Response) -> Optional[Union[List[AModel], HTTPValidationError]]:
+def _parse_response(
+    *, response: httpx.Response
+) -> Optional[Union[List[AModel], HTTPValidationError, HTTPValidationError]]:
     if response.status_code == 200:
         response_200 = []
         _response_200 = response.json()
@@ -61,10 +63,16 @@ def _parse_response(*, response: httpx.Response) -> Optional[Union[List[AModel],
         response_422 = HTTPValidationError.from_dict(response.json())

         return response_422
+    if response.status_code == 423:
+        response_423 = HTTPValidationError.from_dict(response.json())
+
+        return response_423
     return None
     
-def _build_response(*, response: httpx.Response) -> Response[Union[List[AModel], HTTPValidationError]]:
+def _build_response(
+    *, response: httpx.Response
+) -> Response[Union[List[AModel], HTTPValidationError, HTTPValidationError]]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -78,7 +86,7 @@ def sync_detailed(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Response[Union[List[AModel], HTTPValidationError]]:
+) -> Response[Union[List[AModel], HTTPValidationError, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         an_enum_value=an_enum_value,
@@ -97,7 +105,7 @@ def sync(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Optional[Union[List[AModel], HTTPValidationError]]:
+) -> Optional[Union[List[AModel], HTTPValidationError, HTTPValidationError]]:
     """ Get a list of things  """
          return sync_detailed(
@@ -112,7 +120,7 @@ async def asyncio_detailed(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Response[Union[List[AModel], HTTPValidationError]]:
+) -> Response[Union[List[AModel], HTTPValidationError, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         an_enum_value=an_enum_value,
@@ -130,7 +138,7 @@ async def asyncio(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Optional[Union[List[AModel], HTTPValidationError]]:
+) -> Optional[Union[List[AModel], HTTPValidationError, HTTPValidationError]]:
     """ Get a list of things  """

     return (
```
Modified golden records diff after the fix:
```
diff --git a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
index ec22168..2ed83e3 100644
--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -61,6 +61,10 @@ def _parse_response(*, response: httpx.Response) -> Optional[Union[List[AModel],
         response_422 = HTTPValidationError.from_dict(response.json())

         return response_422
+    if response.status_code == 423:
+        response_423 = HTTPValidationError.from_dict(response.json())
+
+        return response_423
     return None
```