### PR TITLE
Allow editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,5 +92,5 @@ skip = [".venv", "tests/test_templates"]
 omit = ["openapi_python_client/templates/*"]
 
 [build-system]
-requires = ["poetry>=1.0"]
+requires = ["setuptools", "poetry>=1.0"]
 build-backend = "poetry.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
I hate to be that guy, but would you consider adding a dumb setup.py so that the library can be installed in editable mode with pip? :)

It baffles me that editable installs are still a hot topic in the packaging game. Here the simplest diff that can allow these I think, and it still saves time when testing changes against a real world codebase.