### PR TITLE
Revert "build: Include a basic setup.py to allow editable installs during development (#370)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,5 +92,5 @@ skip = [".venv", "tests/test_templates"]
 omit = ["openapi_python_client/templates/*"]
 
 [build-system]
-requires = ["setuptools", "poetry>=1.0"]
+requires = ["poetry>=1.0"]
 build-backend = "poetry.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
It seems that hings are more complicated than that. This shim setup.py does
allow the project to be pip -e installed but you don't get the entrypoints,
making it completely useless.

This reverts commit 915183dd181fc2c5619765e245c465a1765102fd.