### PR TITLE
feat!(generator): type and id are allowed as attribute names and will not be converted

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/models/validation_error.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/validation_error.py
@@ -11,20 +11,20 @@ class ValidationError:
 
     loc: List[str]
     msg: str
-    type_: str
+    type: str
 
     def to_dict(self) -> Dict[str, Any]:
         loc = self.loc
 
         msg = self.msg
-        type_ = self.type_
+        type = self.type
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(
             {
                 "loc": loc,
                 "msg": msg,
-                "type": type_,
+                "type": type,
             }
         )
 
@@ -37,12 +37,12 @@ class ValidationError:
 
         msg = d.pop("msg")
 
-        type_ = d.pop("type")
+        type = d.pop("type")
 
         validation_error = cls(
             loc=loc,
             msg=msg,
-            type_=type_,
+            type=type,
         )
 
         return validation_error

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -23,7 +23,7 @@ def fix_keywords(value: str) -> str:
     return value
 
 
-RESERVED_WORDS = set(dir(builtins)).union({"self"})
+RESERVED_WORDS = (set(dir(builtins)) | {"self"}) - {"type", "id"}
 
 
 def fix_reserved_words(value: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,15 @@ def test__fix_keywords():
 
 
 @pytest.mark.parametrize(
-    "reserved_word, expected", [("self", "self_"), ("int", "int_"), ("dict", "dict_"), ("not_reserved", "not_reserved")]
+    "reserved_word, expected",
+    [
+        ("self", "self_"),
+        ("int", "int_"),
+        ("dict", "dict_"),
+        ("not_reserved", "not_reserved"),
+        ("type", "type"),
+        ("id", "id"),
+    ],
 )
 def test__fix_reserved_words(reserved_word: str, expected: str):
     assert utils.fix_reserved_words(reserved_word) == expected


### PR DESCRIPTION
Closes #378 which was reported by @forest-benchling 