### PR TITLE
chore: Prep 0.9.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openapi-python-client"
-version = "0.8.0"
+version = "0.9.0"
 description = "Generate modern Python clients from OpenAPI"
 repository = "https://github.com/triaxtec/openapi-python-client"
 license = "MIT"


### PR DESCRIPTION
Changelog generated by https://github.com/triaxtec/dobby😻 . It's also run through Prettier now, so some older entries are reformatted.