### PR TITLE
fix(parser): Prevent crash when providing a non-string default to a string attribute. Fixes #414

### DIFF
--- a/openapi_python_client/__main__.py
+++ b/openapi_python_client/__main__.py
@@ -1,3 +1,3 @@
-from .cli import cli
+from .cli import app
 
-cli()
+app()

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -151,7 +151,14 @@ class Endpoint:
             body=data.requestBody, schemas=schemas, parent_name=endpoint.name, config=config
         )
         if isinstance(json_body, ParseError):
-            return ParseError(detail=f"cannot parse body of endpoint {endpoint.name}", data=json_body.data), schemas
+            return (
+                ParseError(
+                    header=f"Cannot parse body of endpoint {endpoint.name}",
+                    detail=json_body.detail,
+                    data=json_body.data,
+                ),
+                schemas,
+            )
 
         endpoint.multipart_body_class = Endpoint.parse_multipart_body(body=data.requestBody, config=config)
 

--- a/openapi_python_client/parser/properties/converter.py
+++ b/openapi_python_client/parser/properties/converter.py
@@ -31,7 +31,7 @@ def convert(type_string: str, value: Any) -> Optional[Any]:
         raise ValidationError()
     try:
         return _CONVERTERS[type_string](value)
-    except (KeyError, ValueError) as e:
+    except (KeyError, ValueError, AttributeError) as e:
         raise ValidationError from e
 
 
@@ -58,8 +58,10 @@ def convert_chain(type_strings: Iterable[str], value: Any) -> Optional[Any]:
     raise ValidationError()
 
 
-def _convert_string(value: str) -> Optional[str]:
-    return f"{utils.remove_string_escapes(value)!r}"
+def _convert_string(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        value = utils.remove_string_escapes(value)
+    return repr(value)
 
 
 def _convert_datetime(value: str) -> Optional[str]:

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,7 +1,7 @@
 def test_main(mocker):
-    cli = mocker.patch("openapi_python_client.cli.cli")
+    app = mocker.patch("openapi_python_client.cli.app")
 
     # noinspection PyUnresolvedReferences
     from openapi_python_client import __main__
 
-    cli.assert_called_once()
+    app.assert_called_once()

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -234,7 +234,7 @@ class TestEndpoint:
         from openapi_python_client.parser.openapi import Endpoint, Schemas
 
         mocker.patch.object(Endpoint, "parse_request_form_body")
-        parse_error = ParseError(data=mocker.MagicMock())
+        parse_error = ParseError(data=mocker.MagicMock(), detail=mocker.MagicMock())
         other_schemas = mocker.MagicMock()
         mocker.patch.object(Endpoint, "parse_request_json_body", return_value=(parse_error, other_schemas))
         endpoint = self.make_endpoint()
@@ -249,7 +249,11 @@ class TestEndpoint:
         )
 
         assert result == (
-            ParseError(detail=f"cannot parse body of endpoint {endpoint.name}", data=parse_error.data),
+            ParseError(
+                header=f"Cannot parse body of endpoint {endpoint.name}",
+                detail=parse_error.detail,
+                data=parse_error.data,
+            ),
             other_schemas,
         )
 


### PR DESCRIPTION
1. Fixes #414
2. Changes `__main__` to actually do what it's supposed to for debugging 😅
3. Catches attribute errors when converting defaults to prevent similar future crashes
4. Provides more detail in parse errors on endpoint bodies (needed while debugging)