### PR TITLE
feat: Add option to fail generating client if there are any warnings

### DIFF
--- a/openapi_python_client/cli.py
+++ b/openapi_python_client/cli.py
@@ -54,7 +54,7 @@ def _print_parser_error(e: GeneratorError, color: str) -> None:
     typer.echo()
 
 
-def handle_errors(errors: Sequence[GeneratorError]) -> None:
+def handle_errors(errors: Sequence[GeneratorError], fail_on_warning: bool = False) -> None:
     """Turn custom errors into formatted error messages"""
     if len(errors) == 0:
         return
@@ -91,7 +91,7 @@ def handle_errors(errors: Sequence[GeneratorError]) -> None:
         err=True,
     )
 
-    if error_level == ErrorLevel.ERROR:
+    if error_level == ErrorLevel.ERROR or fail_on_warning:
         raise typer.Exit(code=1)
 
 
@@ -119,6 +119,7 @@ def generate(
     meta: MetaType = _meta_option,
     file_encoding: str = typer.Option("utf-8", help="Encoding used when writing generated"),
     config_path: Optional[pathlib.Path] = CONFIG_OPTION,
+    fail_on_warning: bool = False,
 ) -> None:
     """Generate a new OpenAPI Client library"""
     from . import create_new_client
@@ -145,7 +146,7 @@ def generate(
         file_encoding=file_encoding,
         config=config,
     )
-    handle_errors(errors)
+    handle_errors(errors, fail_on_warning)
 
 
 @app.command()
@@ -156,6 +157,7 @@ def update(
     meta: MetaType = _meta_option,
     file_encoding: str = typer.Option("utf-8", help="Encoding used when writing generated"),
     config_path: Optional[pathlib.Path] = CONFIG_OPTION,
+    fail_on_warning: bool = False,
 ) -> None:
     """Update an existing OpenAPI Client library"""
     from . import update_existing_client
@@ -182,4 +184,4 @@ def update(
         file_encoding=file_encoding,
         config=config,
     )
-    handle_errors(errors)
+    handle_errors(errors, fail_on_warning)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,6 +194,28 @@ class TestGenerate:
             "https://github.com/triaxtec/openapi-python-client/issues/new/choose\n"
         )
 
+    def test_generate_fail_on_warning(self, _create_new_client):
+        error_1 = ParseError(data={"test": "data"}, detail="this is a message")
+        error_2 = ParseError(data={"other": "data"}, detail="this is another message", header="Custom Header")
+        _create_new_client.return_value = [error_1, error_2]
+        path = "cool/path"
+        from openapi_python_client.cli import app
+
+        result = runner.invoke(app, ["generate", f"--path={path}", "--fail-on-warning"])
+
+        assert result.exit_code == 1
+        assert result.output == (
+            "Warning(s) encountered while generating. Client was generated, but some pieces may be missing\n\n"
+            "Unable to parse this part of your OpenAPI document: \n\n"
+            "this is a message\n\n"
+            "{'test': 'data'}\n\n"
+            "Custom Header\n\n"
+            "this is another message\n\n"
+            "{'other': 'data'}\n\n"
+            "If you believe this was a mistake or this tool is missing a feature you need, please open an issue at "
+            "https://github.com/triaxtec/openapi-python-client/issues/new/choose\n"
+        )
+
 
 @pytest.fixture
 def _update_existing_client(mocker):


### PR DESCRIPTION
For our case, we'd rather fail fast than have a potentially incomplete client. I'm open to opinions on the best interface here, like if the flag should be renamed.